### PR TITLE
Arq Task Queue

### DIFF
--- a/.dist.env
+++ b/.dist.env
@@ -15,7 +15,9 @@ DB_PORT=fill  # Optional, remove if unnecessary
 REDIS_IP=fill
 REDIS_PORT=fill
 
-ARQ_BACKGROUND_FUNCTIONS=fill, fill
+# NOTE: Separate function references by comma. Example:
+# ARQ_BACKGROUND_FUNCTIONS=app.path.example_function, app.tasks.example.other_function
+ARQ_BACKGROUND_FUNCTIONS=app.tasks.messaging.send_message
 
 ### Docker Runtime Variables
 # All available options at https://github.com/tiangolo/uvicorn-gunicorn-docker

--- a/.dist.env
+++ b/.dist.env
@@ -12,6 +12,11 @@ DB_PASSWORD=fill  # Optional, remove if unnecessary
 DB_HOST=fill  # Optional, remove if unnecessary
 DB_PORT=fill  # Optional, remove if unnecessary
 
+REDIS_IP=fill
+REDIS_PORT=fill
+
+ARQ_BACKGROUND_FUNCTIONS=fill, fill
+
 ### Docker Runtime Variables
 # All available options at https://github.com/tiangolo/uvicorn-gunicorn-docker
 # Includes custom gunicorn, currency, workers and loging settings

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,7 +5,7 @@ RUN pip install pipenv
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
 
-RUN apk update && apk add --no-cache gcc libffi-dev openssl-dev g++ make
+RUN apk update && apk add --no-cache gcc libffi-dev openssl-dev g++ postgresql-dev make
 
 RUN pipenv install --system --deploy --ignore-pipfile
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,16 @@
+FROM python:3.7-alpine
+
+RUN pip install pipenv
+
+COPY Pipfile Pipfile
+COPY Pipfile.lock Pipfile.lock
+
+RUN apk update && apk add --no-cache gcc libffi-dev openssl-dev g++ make
+
+RUN pipenv install --system --deploy --ignore-pipfile
+
+RUN apk del libffi-dev g++ make
+
+COPY ./app /app
+
+CMD ["arq", "app.worker.WorkerSettings"]

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ black = "*"
 bandit = "*"
 flake8 = "*"
 rope = "*"
+watchgod = "*"
 
 [packages]
 fastapi = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ alembic = "*"
 psycopg2-binary = "*"
 uvicorn = "*"
 email_validator = "*"
+arq = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "71716eab6ce68af37468420abb885dfbfff5229d566cb2771522e8c5cbbb8ebf"
+            "sha256": "c34b37dc136ade5706cdda65b0fbe951b6040998c7c3700b10ca7c0a06ce68b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,11 +39,11 @@
         },
         "arq": {
             "hashes": [
-                "sha256:38ea1ed64540a4a70bc32056bb6d22d3167ecf5fabb8de5dfe76e2d57084394e",
-                "sha256:3a63a214bb0584fea3f914576a16551fbf6ccc43c1147cc5be12ae50fdca89e8"
+                "sha256:2d57685625b15d1dac20159c0032e8105d09ea701c854213b6fe1d75a937b8ee",
+                "sha256:dcdc07cfc38bfd3abb7ff7704d82a603c563b4b63f2d33ec5f104bdfad946870"
             ],
             "index": "pypi",
-            "version": "==0.18"
+            "version": "==0.18.1"
         },
         "async-timeout": {
             "hashes": [
@@ -299,15 +299,17 @@
         },
         "uvloop": {
             "hashes": [
-                "sha256:0deb6c97c5807c792dd9024bab90e6ca49e981862103cb2ea37b430c1ca0a267",
-                "sha256:155b34d513655e753d07f499a7e811970e2d397f240dfcbec0b32a9587159c99",
-                "sha256:1df3ddfa280206e9999ae1c777a20836eb895bcec6dc9fae2cbb6eecfafb099e",
-                "sha256:5b19361c8767e1dc61f6367f948d4f3dc5504b9f2eba488641b3d26ec14498ba",
-                "sha256:942cd07035510b149d6160796f4e972137130ae953871b6a98c2cf5d5ab68c2e",
-                "sha256:c63b6c0bf33144c604dd72f7eecf2d3a3ac7405c503c67bd98128cf306efe18a",
-                "sha256:e698a20a3b4ccb380d207f9d491d4085d7c38d364f6a0bae98684a1612a9607a"
+                "sha256:182617c2992a79b268bfd193691c4aacb93634e9d8d96edf560a842a6206411d",
+                "sha256:2a0268553d2920108b05250c9711060313851daa60b1052c38b6520320aa50b1",
+                "sha256:32d2fe6ee6be28a99661e1f02bf6cedb99711df1065a3fb7ba7dd73ccb85f768",
+                "sha256:448b13a1adfc47745b880b5d5b34c975c7851b1cd3b0eafe2569b2250190c797",
+                "sha256:469e0e3b80f245ed32f054174e6a69e6a01715dbbb24eb917733fe5af09ad306",
+                "sha256:682fa2ab24a758831f531dca122f128373c3dd95a3c8885b5fd1c48775d0024f",
+                "sha256:9967fd537f3164607d153900aaae036e9a18015d8478f84406ba58b183f5abfc",
+                "sha256:9ab030794432c47b78199d3f268ac2c898ae85fb9f09e10ae03dd7af62904b0e",
+                "sha256:c1d55b6926d956a29cf5d7cc891004602ea7cd006b0b80354b9b3d973ca9027f"
             ],
-            "version": "==0.13.0"
+            "version": "==0.14.0rc1"
         },
         "websockets": {
             "hashes": [
@@ -373,11 +375,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "gitdb2": {
             "hashes": [
@@ -475,6 +477,14 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "watchgod": {
+            "hashes": [
+                "sha256:30ffb90c692e0797d23a39d695928c57d8c01a4a9708434e9dca16d7bd4e24c7",
+                "sha256:78d44cbacf4fbbf7573d10fcf0f156f1b0d71598d32477c34f8cf66001bafc1f"
+            ],
+            "index": "pypi",
+            "version": "==0.5"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b94f7ea291eab92fc7e35985473b3e9272e5e6f43b8677267859efc27304e7c"
+            "sha256": "71716eab6ce68af37468420abb885dfbfff5229d566cb2771522e8c5cbbb8ebf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,12 +23,34 @@
             ],
             "version": "==0.2.2"
         },
+        "aioredis": {
+            "hashes": [
+                "sha256:71302cebeb7add86f1fe660b469068760ca4364504e75ee83dd6f6b7118bfe28",
+                "sha256:86da2748fb0652625a8346f413167f078ec72bdc76e217db7e605a059cd56e86"
+            ],
+            "version": "==1.3.0"
+        },
         "alembic": {
             "hashes": [
                 "sha256:9f907d7e8b286a1cfb22db9084f9ce4fde7ad7956bb496dc7c952e10ac90e36a"
             ],
             "index": "pypi",
             "version": "==1.2.1"
+        },
+        "arq": {
+            "hashes": [
+                "sha256:38ea1ed64540a4a70bc32056bb6d22d3167ecf5fabb8de5dfe76e2d57084394e",
+                "sha256:3a63a214bb0584fea3f914576a16551fbf6ccc43c1147cc5be12ae50fdca89e8"
+            ],
+            "index": "pypi",
+            "version": "==0.18"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "version": "==3.0.1"
         },
         "asyncpg": {
             "hashes": [
@@ -94,6 +116,39 @@
                 "sha256:f2b1ca39bfed357d1f19ac732913d5f9faa54a5062eca7d2ec3a916cfb7ae4c7"
             ],
             "version": "==0.8.1"
+        },
+        "hiredis": {
+            "hashes": [
+                "sha256:0124911115f2cb7deb4f8e221e109a53d3d718174b238a2c5e2162175a3929a5",
+                "sha256:0656658d0448c2c82c4890ae933c2c2e51196101d3d06fc19cc92e062410c2fd",
+                "sha256:09d284619f7142ddd7a4ffa94c12a0445e834737f4ce8739a737f2b1ca0f6142",
+                "sha256:12299b7026e5dc22ed0ff603375c1bf583cf59adbb0e4d062df434e9140d72dd",
+                "sha256:12fc6210f8dc3e9c8ce4b95e8f5db404b838dbdeb25bca41e33497de6d89334f",
+                "sha256:197febe5e63c77f4ad19b36e15ed33152064dc606c8b7413c7a0ca3fd04672cc",
+                "sha256:20e48289fbffb59a5ac7cc677fc02c2726c1da22488e5f7636b9feb9afde199f",
+                "sha256:26bed296b92b88db02afe214aa1fefad7f9e8ba88a5a7c0e355b55c4b168d212",
+                "sha256:321b19d2a21fd576111032fe7694d317de2c11b265ef775f2e3f22734a6b94c8",
+                "sha256:32d5f2c461250f5fc7ccef647682651b1d9f69443f16c213d7fa5e183222b233",
+                "sha256:36bfcc86715d109a5ef6edefd52b893de97d555cb5cb0e9cab83eb9665942ccc",
+                "sha256:438ddfd1484e98110959dc4648c0ba22c3307c9c0ae7e2a856755067f9ce9cef",
+                "sha256:66f17c1633b2fb967bf4165f7b3d369a1bdfe3537d3646cf9a7c208506c96c49",
+                "sha256:94ab0fa3ac93ab36a5400c474439881d182b43fd38a2766d984470c57931ae88",
+                "sha256:955f12da861f2608c181049f623bbb52851769e10639c4919cc586395b89813f",
+                "sha256:b1fd831f96ce0f715e9356574f5184b840b59eb8901fc5f9124fedbe84ad2a59",
+                "sha256:b3813c641494fca2eda66c32a2117816472a5a39b12f59f7887c6d17bdb8c77e",
+                "sha256:bbc3ee8663024c82a1226a0d56ad882f42a2fd8c2999bf52d27bdd25f1320f4b",
+                "sha256:bd12c2774b574f5b209196e25b03b5d62c7919bf69046bc7b955ebe84e0ec1fe",
+                "sha256:c54d2b3d7a2206df35f3c1140ac20ca6faf7819ff92ea5be8bf4d1cbdb433216",
+                "sha256:c7b0bcaf2353a2ad387dd8b5e1b5f55991adc3a7713ac3345a4ef0de58276690",
+                "sha256:c9319a1503efb3b5a4ec13b2f8fae2c23610a645e999cb8954d330f0610b0f6d",
+                "sha256:cbe5c0273224babe2ec77058643312d07aa5e8fed08901b3f7bccaa744c5728e",
+                "sha256:cc884ea50185009d794b31314a144110efc76b71beb0a5827a8bff970ae6d248",
+                "sha256:d1e2e751327781ad81df5a5a29d7c7b19ee0ebfbeddf037fd8df19ec1c06e18b",
+                "sha256:d2ef58cece6cae4b354411df498350d836f10b814c8a890df0d8079aff30c518",
+                "sha256:e97c953f08729900a5e740f1760305434d62db9f281ac351108d6c4b5bf51795",
+                "sha256:fcdf2e10f56113e1cb4326dbca7bf7edbfdbd246cd6d7ec088688e5439129e2c"
+            ],
+            "version": "==1.0.0"
         },
         "httptools": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 ### Run Locally with Docker-Compose
 1. Clone this Repository. `git clone https://github.com/leosussan/fastapi-gino-postgres.git`
 2. Generate a DB Migration: `alembic revision --autogenerate`.*
-3. Run locally using docker-compose. `docker-compose -f docker-compose.local.yml -f docker-compose.yml up --build`.
+3. Run locally using docker-compose. `docker-compose -f docker-compose.local.yml -f docker-compose.worker.yml -f docker-compose.yml up --build`.
 
 *`app/settings/prestart.sh` will run migrations for you before the app starts.
 
@@ -27,6 +27,7 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 * Store complex db queries in `/app/models/orm/queries`
 * Store complex tasks for foreground + background in `app/tasks`.
 * Add / edit globals to `/.env`, expose & import them from `/app/settings/globals.py`
+    * Add background coroutines to the `ARQ_BACKGROUND_FUNCTIONS` global
 * Define code to run before launch (migrations, setup, etc) in `/app/settings/prestart.sh`
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fastapi-gino-postgres
+# fastapi-arq-gino-postgres
 High-performance Async REST API, in Python. FastAPI + GINO + Uvicorn + PostgreSQL.
 
 ## Get Started
@@ -7,7 +7,7 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 
 1. Clone this Repository. `git clone https://github.com/leosussan/fastapi-gino-postgres.git`
 2. Run `pipenv install` from root. (Run `pip install pipenv` first, if necessary.)
-3. Make a copy of `.dist.env`, rename to `.env`. Fill in PostgreSQL connection vars.
+3. Make a copy of `.dist.env`, rename to `.env`. Fill in PostgreSQL, Redis connection vars.
 4. Generate DB Migrations: `alembic revision --autogenerate`. It will be applied when the application starts. You can trigger manually with `alembic upgrade head`.
 5. Run:
     * _For Active Development (w/ auto-reload):_ Run locally with `pipenv run uvicorn app.main:app --reload `
@@ -25,6 +25,7 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 * Create database models to `/app/models/orm`, add them to `/app/models/orm/migrations/env.py` for migrations
 * Create pydantic models in `/app/models/pydantic`
 * Store complex db queries in `/app/models/orm/queries`
+* Store complex tasks for foreground + background in `app/tasks`.
 * Add / edit globals to `/.env`, expose & import them from `/app/settings/globals.py`
 * Define code to run before launch (migrations, setup, etc) in `/app/settings/prestart.sh`
 
@@ -33,10 +34,12 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 * **FastAPI:** touts performance on-par with NodeJS & Go + automatic Swagger + ReDoc generation. 
 * **GINO:** built on SQLAlchemy core. Lightweight, simple, asynchronous ORM for PostgreSQL.
 * **Uvicorn:** Lightning-fast, asynchronous ASGI server.
-* **PostgreSQL:** Robust, fully-featured, scalable, open-source.
+* **ARQ:** Asyncio + Redis = fast, resource-light job queuing & RPC.
 * **Optimized Dockerfile:** Optimized Dockerfile for ASGI applications, from https://github.com/tiangolo/uvicorn-gunicorn-docker.
 
 #### Additional Dependencies
 * **Pydantic:** Core to FastAPI. Define how data should be in pure, canonical python; validate it with pydantic. 
 * **Alembic:** Handles database migrations. Compatible with GINO.
 * **SQLAlchemy_Utils:** Provides essential handles & datatypes. Compatible with GINO.
+* **PostgreSQL:** Robust, fully-featured, scalable, open-source.
+* **Redis:** Fast, simple, broker for the Arq task queue.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 * Create database models to `/app/models/orm`, add them to `/app/models/orm/migrations/env.py` for migrations
 * Create pydantic models in `/app/models/pydantic`
 * Store complex db queries in `/app/models/orm/queries`
-* Store complex tasks for foreground + background in `app/tasks`.
+* Store complex tasks in `app/tasks`.
 * Add / edit globals to `/.env`, expose & import them from `/app/settings/globals.py`
-    * Add background coroutines to the `ARQ_BACKGROUND_FUNCTIONS` global
+    * Use any coroutine as a background function: store a reference in the `ARQ_BACKGROUND_FUNCTIONS` env.
 * Define code to run before launch (migrations, setup, etc) in `/app/settings/prestart.sh`
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ High-performance Async REST API, in Python. FastAPI + GINO + Uvicorn + PostgreSQ
 _NOTE: You must have PostgreSQL & Redis running locally._
 
 1. Clone this Repository. `git clone https://github.com/leosussan/fastapi-gino-postgres.git`
-2. Run `pipenv install` from root. (Run `pip install pipenv` first, if necessary.)
+2. Run `pipenv install --dev` from root. (Run `pip install pipenv` first, if necessary.)
 3. Make a copy of `.dist.env`, rename to `.env`. Fill in PostgreSQL, Redis connection vars.
 4. Generate DB Migrations: `alembic revision --autogenerate`. It will be applied when the application starts. You can trigger manually with `alembic upgrade head`.
 5. Run:
-    * _For Active Development (w/ auto-reload):_ Run locally with `pipenv run uvicorn app.main:app --reload `
-    * _For Debugging (compatible w/ debuggers, no auto-reload):_ Configure debugger to run `python app/main.py`.
+    - FastAPI Application:
+        * _For Active Development (w/ auto-reload):_ Run locally with `pipenv run uvicorn app.main:app --reload `
+        * _For Debugging (compatible w/ debuggers, no auto-reload):_ Configure debugger to run `python app/main.py`.
+    - Background Task Worker:
+        * _For Active Development:_ Run with `pipenv run arq app.worker.Worker --watch ./`
 
 ### Run Locally with Docker-Compose
 1. Clone this Repository. `git clone https://github.com/leosussan/fastapi-gino-postgres.git`
@@ -34,8 +37,8 @@ _NOTE: You must have PostgreSQL & Redis running locally._
 ### Core Dependencies
 * **FastAPI:** touts performance on-par with NodeJS & Go + automatic Swagger + ReDoc generation. 
 * **GINO:** built on SQLAlchemy core. Lightweight, simple, asynchronous ORM for PostgreSQL.
+* **Arq:** Asyncio + Redis = fast, resource-light job queuing & RPC.
 * **Uvicorn:** Lightning-fast, asynchronous ASGI server.
-* **ARQ:** Asyncio + Redis = fast, resource-light job queuing & RPC.
 * **Optimized Dockerfile:** Optimized Dockerfile for ASGI applications, from https://github.com/tiangolo/uvicorn-gunicorn-docker.
 
 #### Additional Dependencies

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ High-performance Async REST API, in Python. FastAPI + GINO + Uvicorn + PostgreSQ
 
 ## Get Started
 ### Run Locally
+_NOTE: You must have PostgreSQL & Redis running locally._
+
 1. Clone this Repository. `git clone https://github.com/leosussan/fastapi-gino-postgres.git`
 2. Run `pipenv install` from root. (Run `pip install pipenv` first, if necessary.)
-3. Rename `.dist.env` to `.env`. Fill in PostgreSQL connection vars.
+3. Make a copy of `.dist.env`, rename to `.env`. Fill in PostgreSQL connection vars.
 4. Generate DB Migrations: `alembic revision --autogenerate`. It will be applied when the application starts. You can trigger manually with `alembic upgrade head`.
 5. Run:
     * _For Active Development (w/ auto-reload):_ Run locally with `pipenv run uvicorn app.main:app --reload `

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,10 @@
 import sys
 
-sys.path.extend(['./'])
+sys.path.extend(["./"])
 from app.application import app
 from app.routes.users import router as user_router
 
-ROUTERS = (user_router, )
+ROUTERS = (user_router,)
 
 for r in ROUTERS:
     app.include_router(r)

--- a/app/models/pydantic/database.py
+++ b/app/models/pydantic/database.py
@@ -7,11 +7,19 @@ from starlette.datastructures import Secret
 
 
 class DatabaseURL(BaseModel):
-    drivername: str = Schema(..., alias="driver", description="The database driver.")
-    host: str = Schema('localhost', description="Server host.")
-    port: Optional[Union[str, int]] = Schema(None, description="Server access port.")
-    username: Optional[str] = Schema(None, alias='user', description="Username")
-    password: Optional[Union[str, Secret]] = Schema(None, description="Password")
+    drivername: str = Schema(
+        ..., alias="driver", description="The database driver."
+    )
+    host: str = Schema("localhost", description="Server host.")
+    port: Optional[Union[str, int]] = Schema(
+        None, description="Server access port."
+    )
+    username: Optional[str] = Schema(
+        None, alias="user", description="Username"
+    )
+    password: Optional[Union[str, Secret]] = Schema(
+        None, description="Password"
+    )
     database: str = Schema(..., description="Database name.")
     url: Optional[URL] = None
 
@@ -19,7 +27,7 @@ class DatabaseURL(BaseModel):
         arbitrary_types_allowed = True
         allow_population_by_alias = True
 
-    @validator('url', always=True)
+    @validator("url", always=True)
     def build_url(cls, v: Any, field: Field, values: dict):
         if isinstance(v, URL):
             return v

--- a/app/models/pydantic/user.py
+++ b/app/models/pydantic/user.py
@@ -7,19 +7,19 @@ from .base import Base
 class User(Base):
     name: str
     email: EmailStr
-    _phone_number: str
+    phone_number: str
     country_code: str
 
 
 class UserCreateIn(BaseModel):
     name: str
     email: EmailStr
-    _phone_number: str
+    phone_number: str
     country_code: str
 
 
 class UserUpdateIn(BaseModel):
     name: Optional[str]
     email: Optional[EmailStr]
-    _phone_number: Optional[str]
+    phone_number: Optional[str]
     country_code: Optional[str]

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,32 +1,32 @@
 from fastapi import APIRouter
 
-from ..models.orm.user import User
-from ..models.pydantic.user import User as UserSchema, UserCreateIn, UserUpdateIn
+from ..models.orm.user import ORMUser
+from ..models.pydantic.user import User, UserCreateIn, UserUpdateIn
 
 router = APIRouter()
 
 
-@router.post('/users', tags=['Users'], response_model=UserSchema)
+@router.post("/users", tags=["Users"], response_model=User)
 async def create_user(request: UserCreateIn):
-    new_user: User = await User.create(**request.dict())
-    return UserSchema.from_orm(new_user)
+    new_user: ORMUser = await ORMUser.create(**request.dict())
+    return User.from_orm(new_user)
 
 
-@router.get('/users/{id}', tags=['Users'], response_model=UserSchema)
+@router.get("/users/{id}", tags=["Users"], response_model=User)
 async def retrieve_user(id: int):
-    user: User = await User.get(id)
-    return UserSchema.from_orm(user)
+    user: ORMUser = await ORMUser.get(id)
+    return User.from_orm(user)
 
 
-@router.put('/users/{id}', tags=['Users'], response_model=UserSchema)
+@router.put("/users/{id}", tags=["Users"], response_model=User)
 async def update_user(request: UserUpdateIn, id: int):
-    user: User = await User.get(id)
-    updated_fields: UserSchema = UserSchema.from_orm(request)
+    user: ORMUser = await ORMUser.get(id)
+    updated_fields: User = User.from_orm(request)
     await user.update(**updated_fields.dict(skip_defaults=True)).apply()
-    return UserSchema.from_orm(user)
+    return User.from_orm(user)
 
 
-@router.delete('/users/{id}', tags=['Users'], response_model=UserSchema)
+@router.delete("/users/{id}", tags=["Users"], response_model=User)
 async def delete_user(id: int):
-    user: User = await User.get(id)
+    user: ORMUser = await ORMUser.get(id)
     return await user.delete()

--- a/app/settings/arq.py
+++ b/app/settings/arq.py
@@ -1,0 +1,5 @@
+from arq.connections import RedisSettings
+
+from .globals import REDIS_IP, REDIS_PORT
+
+settings = RedisSettings(host=REDIS_IP, port=REDIS_PORT)

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -2,19 +2,40 @@ from pathlib import Path
 from typing import Optional
 
 from starlette.config import Config
-from starlette.datastructures import Secret
+from starlette.datastructures import Secret, CommaSeparatedStrings
 
 from ..models.pydantic.database import DatabaseURL
 
-p: Path = Path(__file__).parents[2] / '.env'
+p: Path = Path(__file__).parents[2] / ".env"
 config: Config = Config(p if p.exists() else None)
 
-DATABASE: str = config('DATABASE', cast=str)
-DB_USER: Optional[str] = config('DB_USER', cast=str, default=None)
-DB_PASSWORD: Optional[Secret] = config('DB_PASSWORD', cast=Secret, default=None)
-DB_HOST: str = config('DB_HOST', cast=str, default='localhost')
-DB_PORT: int = config('DB_PORT', cast=int, default=5432)
-DATABASE_CONFIG: DatabaseURL = DatabaseURL(drivername="asyncpg", username=DB_USER, password=DB_PASSWORD, host=DB_HOST,
-                                           port=DB_PORT, database=DATABASE)
-ALEMBIC_CONFIG: DatabaseURL = DatabaseURL(drivername="postgresql+psycopg2", username=DB_USER, password=DB_PASSWORD,
-                                          host=DB_HOST, port=DB_PORT, database=DATABASE)
+DATABASE: str = config("DATABASE", cast=str)
+DB_USER: Optional[str] = config("DB_USER", cast=str, default=None)
+DB_PASSWORD: Optional[Secret] = config(
+    "DB_PASSWORD", cast=Secret, default=None
+)
+DB_HOST: str = config("DB_HOST", cast=str, default="localhost")
+DB_PORT: int = config("DB_PORT", cast=int, default=5432)
+DATABASE_CONFIG: DatabaseURL = DatabaseURL(
+    drivername="asyncpg",
+    username=DB_USER,
+    password=DB_PASSWORD,
+    host=DB_HOST,
+    port=DB_PORT,
+    database=DATABASE,
+)
+ALEMBIC_CONFIG: DatabaseURL = DatabaseURL(
+    drivername="postgresql+psycopg2",
+    username=DB_USER,
+    password=DB_PASSWORD,
+    host=DB_HOST,
+    port=DB_PORT,
+    database=DATABASE,
+)
+
+REDIS_IP: str = config("REDIS_IP", cast=str, default="127.0.0.1")
+REDIS_PORT: int = config("REDIS_PORT", cast=int, default=6379)
+
+ARQ_BACKGROUND_FUNCTIONS: Optional[CommaSeparatedStrings] = config(
+    "ARQ_BACKGROUND_FUNCTIONS", cast=CommaSeparatedStrings, default=None
+)

--- a/app/tasks/messaging.py
+++ b/app/tasks/messaging.py
@@ -1,4 +1,4 @@
-from ..main import db
+from ..application import db
 from ..models.pydantic.user import User
 from ..models.orm.user import User as ORMUser
 

--- a/app/tasks/messaging.py
+++ b/app/tasks/messaging.py
@@ -1,0 +1,15 @@
+from ..main import db
+from ..models.pydantic.user import User
+from ..models.orm.user import User as ORMUser
+
+
+async def send_message(ctx: dict, user_id: int, message: str):
+    # TODO: Add a messaging service.
+    orm_user: ORMUser = await ORMUser.get(user_id)
+    user: User = User.from_orm(orm_user)
+    print(
+        "Message sent to {phone_number}: {message}".format(
+            phone_number=user.phone_number, message=message
+        )
+    )
+    return user

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-from app.application import db
+from app.main import db
 from app.settings.arq import settings
 from app.settings.globals import DATABASE_CONFIG, ARQ_BACKGROUND_FUNCTIONS
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,39 @@
+from importlib import import_module
+
+from app.application import db
+from app.settings.arq import settings
+from app.settings.globals import DATABASE_CONFIG, ARQ_BACKGROUND_FUNCTIONS
+
+
+FUNCTIONS: list = [
+    getattr(import_module(function_path), function_name)
+    for function_path, function_name in [
+        background_function.rsplit(".", 1)
+        for background_function in list(ARQ_BACKGROUND_FUNCTIONS)
+    ]
+] if ARQ_BACKGROUND_FUNCTIONS is not None else list()
+
+
+async def startup(ctx):
+    """
+    Binds a connection set to the db object.
+    """
+    await db.set_bind(DATABASE_CONFIG.url)
+
+
+async def shutdown(ctx):
+    """
+    Pops the bind on the db object.
+    """
+    await db.pop_bind().close()
+
+
+class WorkerSettings:
+    """
+    Settings for the ARQ worker.
+    """
+
+    on_startup = startup
+    on_shutdown = shutdown
+    redis_settings = settings
+    functions: list = FUNCTIONS

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,8 +1,8 @@
 from importlib import import_module
 
-from app.main import db
-from app.settings.arq import settings
-from app.settings.globals import DATABASE_CONFIG, ARQ_BACKGROUND_FUNCTIONS
+from .application import db
+from .settings.arq import settings
+from .settings.globals import DATABASE_CONFIG, ARQ_BACKGROUND_FUNCTIONS
 
 
 FUNCTIONS: list = [

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,6 +5,8 @@ services:
     container_name: fastapi-gino-postgres
     image: fastapi-gino-postgres
     environment:
+      - REDIS_IP=cache
+      - REDIS_PORT=6379
       - DB_HOST=database
       - DATABASE=postgres
       - DB_USER=postgres
@@ -20,12 +22,14 @@ services:
     depends_on:
       - database
       - redis
-    volumes:
-      - cloudsql:/cloudsql
     environment:
       - REDIS_IP=cache
       - REDIS_PORT=6379
-      - CLOUDSQL_CONNECTION_METHOD=unix
+      - DB_HOST=database
+      - DATABASE=postgres
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_PORT=5432
     env_file: .env
 
   redis:
@@ -45,4 +49,5 @@ services:
     volumes:
       - database_data:/var/lib/postgresql/data
 
-volumes: database_data:
+volumes:
+  database_data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,10 +12,31 @@ services:
       - DB_PORT=5432
     depends_on:
       - database
+      - redis
+
+  worker:
+    container_name: fastapi-gino-postgres-worker
+    image: fastapi-gino-postgres-worker
+    depends_on:
+      - database
+      - redis
+    volumes:
+      - cloudsql:/cloudsql
+    environment:
+      - REDIS_IP=cache
+      - REDIS_PORT=6379
+      - CLOUDSQL_CONNECTION_METHOD=unix
+    env_file: .env
+
+  redis:
+    image: redis
+    container_name: cache
+    expose:
+      - 6379
 
   database:
     image: "postgres:latest"
-    container_name: postgresql
+    container_name: database
     restart: always
     ports:
       - 54320:5432

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    container_name: fastapi-gino-postgres-worker
+    image: fastapi-gino-postgres-worker
+    env_file: .env
+    environment:
+      - COMPOSE_CONVERT_WINDOWS_PATHS=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '3'
+version: "3"
 
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: fastapi-gino-postgres
     image: fastapi-gino-postgres
     env_file: .env


### PR DESCRIPTION
Implements @samuelcolvin's Arq task queue for robust job / RPC handling.

PR includes:

- Distinct `Dockerfile.worker`, `docker-compose.worker.yml`
- Updated `docker-compose.local.yml` spins up Redis and worker
- `ARQ_BACKGROUND_FUNCTIONS` global: a string-separated list of function references. All listed functions made available to worker at instantiation
- New `tasks` folder for complicated application logic: `app/tasks`
- Example background function in `app/tasks/messaging/send_message`
- Example use of above background function in `app/routes/users/create_user`

Documentation: https://github.com/samuelcolvin/arq